### PR TITLE
Suppress Curl output

### DIFF
--- a/src/idid.sh
+++ b/src/idid.sh
@@ -45,7 +45,7 @@ cat > $tmp_file << DONE
 {"team": "${base_uri}/teams/${team_short_name}/", "raw_text": "${done}", "done_date": "${done_date}"}
 DONE
 ### submit done to api saving the return response
-res=$(curl -H "Content-type:application/json" -H "Authorization: Token ${api_token}" --data @${tmp_file} ${base_uri}/dones/)
+res=$(curl -s -H "Content-type:application/json" -H "Authorization: Token ${api_token}" --data @${tmp_file} ${base_uri}/dones/)
 
 ## if it was successful print out success message
 ## if the request failed, print it


### PR DESCRIPTION
The `-s` option means that no spare output gets sent from Curl, showing up in the Alfred debugging screen, see the [Curl manual](https://curl.haxx.se/docs/manpage.html#-s).

> Silent or quiet mode. Don't show progress meter or error messages. Makes Curl mute. It will still output the data you ask for, potentially even to the terminal/stdout unless you redirect it.
